### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,4 +1,6 @@
 name: Windows build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ewdlop/Campfire/security/code-scanning/1](https://github.com/ewdlop/Campfire/security/code-scanning/1)

To fix this problem, we should add a `permissions` block to the workflow, specifying the minimum necessary permissions for the job. As this workflow only checks out code and builds (with no write actions on the repository, or other operations requiring elevated privileges), `contents: read` is likely sufficient. To ensure all jobs (here, just one: `build`) inherit the least privilege, add this block at the top of the workflow (below the `name:` but above `on:` is conventional). No additional imports or steps are required; just the insertion of the `permissions` YAML block.

- Insert `permissions:` at the root of `.github/workflows/windows-build.yml`, after line 1.
- Set `contents: read` as the minimal privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
