### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,4 +1,6 @@
 name: Ubuntu build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ewdlop/Campfire/security/code-scanning/2](https://github.com/ewdlop/Campfire/security/code-scanning/2)

To fix this problem, add a `permissions` block at the root level of the workflow file (`.github/workflows/c-cpp.yml`). This should be placed immediately after the `name:` field and before the `on:` field, with a minimal privilege set—typically `contents: read` is sufficient for a build workflow that just checks out code and builds/tests it. No existing actions in the workflow require broader access. If in the future, other jobs require different permissions, they can override this block at the job level. The change only involves inserting three lines with proper YAML indentation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
