### PR TITLE
Potential fix for code scanning alert no. 5: Incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/Vendor/imgui/src/imgui_widgets.cpp
+++ b/Vendor/imgui/src/imgui_widgets.cpp
@@ -1799,7 +1799,7 @@ bool ImGui::DataTypeApplyOpFromText(const char* buf, const char* initial_value_b
         // Store operand in a float so we can use fractional value for multipliers (*1.1), but constant always parsed as integer so we can fit big integers (e.g. 2000000003) past float precision
         if (op == '+')      { if (sscanf(buf, "%d", &arg1i)) *v = (int)(arg0i + arg1i); }                   // Add (use "+-" to subtract)
         else if (op == '*') { if (sscanf(buf, "%f", &arg1f)) *v = (int)(arg0i * arg1f); }                   // Multiply
-        else if (op == '/') { if (sscanf(buf, "%f", &arg1f) && arg1f != 0.0f) *v = (int)(arg0i / arg1f); }  // Divide
+        else if (op == '/') { if (sscanf(buf, "%f", &arg1f) == 1 && arg1f != 0.0f) *v = (int)(arg0i / arg1f); }  // Divide
         else                { if (sscanf(buf, format, &arg1i) == 1) *v = arg1i; }                           // Assign constant
     }
     else if (data_type == ImGuiDataType_Float)


### PR DESCRIPTION
Potential fix for [https://github.com/ewdlop/Campfire/security/code-scanning/5](https://github.com/ewdlop/Campfire/security/code-scanning/5)

The best way to fix the problem is to check the return value of `sscanf` against the exact number of arguments expected to be assigned, rather than simply evaluating its truthiness or comparing to zero. Specifically, replace `if (sscanf(buf, "%f", &arg1f) && arg1f != 0.0f)` with `if (sscanf(buf, "%f", &arg1f) == 1 && arg1f != 0.0f)`, ensuring we enter the conditional only if one item was successfully parsed and assigned. This change should be made only within the code block dealing with input of `ImGuiDataType_S32` and the specific operator `/`, where this idiom is used (line 1802). No import, function, or definition changes are needed; only the conditional in this line should be updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
